### PR TITLE
fix(auth): route password reset through /auth/callback to bypass allo…

### DIFF
--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -6,6 +6,8 @@ export async function GET(request: Request) {
   const code = requestUrl.searchParams.get("code")
   const tokenHash = requestUrl.searchParams.get("token_hash")
   const tokenType = requestUrl.searchParams.get("type")?.toLowerCase() ?? null
+  const next = requestUrl.searchParams.get("next")
+  const gymCode = requestUrl.searchParams.get("gym")
 
   const supabase = await createServerSupabaseClient()
   let authError: string | null = null
@@ -26,6 +28,15 @@ export async function GET(request: Request) {
 
   if (authError) {
     return NextResponse.redirect(new URL(`/login?error=${encodeURIComponent(authError)}`, requestUrl.origin))
+  }
+
+  // Password reset: forward to /reset-password so the user can set a new password.
+  // The session is now established (code was exchanged above), so the reset page
+  // will find a valid user via getUser() without needing to re-exchange anything.
+  if (next === "/reset-password") {
+    const resetParams = new URLSearchParams({ reset: "1" })
+    if (gymCode) resetParams.set("gym", gymCode)
+    return NextResponse.redirect(new URL(`/reset-password?${resetParams.toString()}`, requestUrl.origin))
   }
 
   const {

--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -11,12 +11,7 @@ function ResetPasswordContent() {
   const supabase = useMemo(() => createClient(), []);
   const router = useRouter();
   const searchParams = useSearchParams();
-  // gymCode may come from the URL (?gym=) or from sessionStorage set by LoginForm.
-  // We prefer the URL param (tamper-evident); sessionStorage is the fallback for
-  // the common case where redirectTo couldn't carry query params through Supabase.
-  const gymCode = searchParams.get('gym')?.trim() || (() => {
-    try { return sessionStorage.getItem('stren.reset.gymCode') } catch { return null }
-  })();
+  const gymCode = searchParams.get('gym')?.trim() || null;
   const { completePasswordSetup, signIn, signOut } = useAuth();
 
   // Session bootstrap state
@@ -110,9 +105,6 @@ function ResetPasswordContent() {
       setIsSubmitting(false);
       return;
     }
-
-    // Clear the stored gym code regardless of outcome.
-    try { sessionStorage.removeItem('stren.reset.gymCode') } catch { /* ignore */ }
 
     // If this reset came from a gym login page, verify the account belongs to that gym.
     if (gymCode && signInResult.profile) {

--- a/components/auth/LoginForm.tsx
+++ b/components/auth/LoginForm.tsx
@@ -175,13 +175,13 @@ export function LoginForm({ gymCode, initialOriginPath }: LoginFormProps) {
       }
     }
 
-    // Store gymCode in sessionStorage so the reset page can read it back.
-    // We do NOT put ?gym= in the redirectTo URL — Supabase uses exact matching
-    // on the allowlist so query params would cause it to fall back to site_url.
-    if (gymCode) {
-      try { sessionStorage.setItem('stren.reset.gymCode', gymCode) } catch { /* ignore */ }
-    }
-    const redirectTo = `${window.location.origin}/reset-password`;
+    // Route through /auth/callback which is already in the Supabase allowlist.
+    // The callback exchanges the PKCE code server-side then forwards to /reset-password.
+    // We pass gym as a query param on the callback URL (not the final redirectTo)
+    // so the allowlist only needs to match /auth/callback exactly.
+    const callbackParams = new URLSearchParams({ next: '/reset-password' });
+    if (gymCode) callbackParams.set('gym', gymCode);
+    const redirectTo = `${window.location.origin}/auth/callback?${callbackParams.toString()}`;
     const { error: resetError } = await supabase.auth.resetPasswordForEmail(email, { redirectTo });
 
     if (resetError) {


### PR DESCRIPTION
…wlist issue

Supabase was ignoring the /reset-password redirectTo (not matching the allowlist) and falling back to site_url, landing users on the home page.

Route reset emails through /auth/callback?next=/reset-password&gym=CODE instead — the callback URL is already in the allowlist. The callback exchanges the PKCE code server-side, then forwards to /reset-password with ?gym= and ?reset=1 so the reset page receives a live session and the gym context without needing to re-exchange anything.


Claude-Session: https://claude.ai/code/session_01FNyzqvMzSA6zFZshQxgjii