### PR TITLE
fix: safety net for stray auth codes on / and /landing

### DIFF
--- a/app/landing/page.tsx
+++ b/app/landing/page.tsx
@@ -1,8 +1,30 @@
+import { redirect } from 'next/navigation';
 import { LandingNav } from '@/components/landing/landing-nav';
 import { LandingClientPage } from '@/components/landing/landing-client-page';
 import '@/styles/swiper-custom.css';
 
-export default function LandingPage() {
+// Safety net: catch any auth code/token_hash that Supabase drops here instead
+// of at /auth/callback (e.g. after the root redirect strips the query string).
+export default function LandingPage({
+  searchParams,
+}: {
+  searchParams?: Record<string, string>;
+}) {
+  const sp = searchParams ?? {};
+  const code = sp['code'];
+  const tokenHash = sp['token_hash'];
+  const type = sp['type'];
+
+  if (code || tokenHash) {
+    const params = new URLSearchParams(
+      Object.entries(sp).filter(([, v]) => v !== undefined) as [string, string][],
+    );
+    if (type === 'recovery' && !params.has('next')) {
+      params.set('next', '/reset-password');
+    }
+    redirect(`/auth/callback?${params.toString()}`);
+  }
+
   return (
     <div style={{ backgroundColor: 'var(--color-background)' }}>
       <LandingNav />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,27 @@
 import { redirect } from 'next/navigation';
 
-export default function Home() {
+// Safety net: if Supabase drops an auth code or token_hash on the Site URL
+// (e.g. when redirect_to allowlist matching strips query params), forward it
+// to /auth/callback so the session exchange still works.
+export default function Home({
+  searchParams,
+}: {
+  searchParams: Record<string, string>;
+}) {
+  const code = searchParams['code'];
+  const tokenHash = searchParams['token_hash'];
+  const type = searchParams['type'];
+
+  if (code || tokenHash) {
+    const params = new URLSearchParams(
+      Object.entries(searchParams).filter(([, v]) => v !== undefined) as [string, string][],
+    );
+    // Recovery tokens should land on the reset-password form, not the normal post-login route.
+    if (type === 'recovery' && !params.has('next')) {
+      params.set('next', '/reset-password');
+    }
+    redirect(`/auth/callback?${params.toString()}`);
+  }
+
   redirect('/landing');
 }


### PR DESCRIPTION
When Supabase falls back to the Site URL (stripping redirect_to query params), auth codes or token_hashes land on the root or /landing route. Both pages now detect these params and forward to /auth/callback, preserving all params and injecting next=/reset-password for recovery flows.


Claude-Session: https://claude.ai/code/session_01FNyzqvMzSA6zFZshQxgjii